### PR TITLE
게시판 api 만들기 - Data Rest 적용 및 테스트 정의

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,9 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest' //rest-api를 사용하기 쉽게 만드는 라이브러리
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'	//rest-api를 테스트할 수 있게 해주는 라이브러리
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'mysql:mysql-connector-java'

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleCommentRepository.java
@@ -2,8 +2,10 @@ package com.fastcampus.fastcampusprojectboard.repository;
 
 import com.fastcampus.fastcampusprojectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 
 }

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleRepository.java
@@ -2,8 +2,9 @@ package com.fastcampus.fastcampusprojectboard.repository;
 
 import com.fastcampus.fastcampusprojectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,6 +26,9 @@ spring:
       hibernate.default_batch_fetch_size: 100
 #  h2.console.enabled: true
   sql.init.mode: always
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated
 #================================================================
 
 #debug: false

--- a/src/test/java/com/fastcampus/fastcampusprojectboard/controller/DataRestTest.java
+++ b/src/test/java/com/fastcampus/fastcampusprojectboard/controller/DataRestTest.java
@@ -1,0 +1,92 @@
+package com.fastcampus.fastcampusprojectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@DisplayName("Data Rest - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        //Given
+
+        //When
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+        //Then
+    }
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void givenNothing_whenRequestSingleArticle_thenReturnsArticlesJsonResponse() throws Exception {
+        //Given
+
+        //When
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+        //Then
+    }
+
+    @DisplayName("[api] 게시글 -> 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestArticlesCommentFromArticle_thenReturnsArticlesCommentsJsonResponse() throws Exception {
+        //Given
+
+        //When
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+        //Then
+    }
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequestArticlesComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        //Given
+
+        //When
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+        //Then
+    }
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void givenNothing_whenRequestArticlesComment_thenReturnsArticlesCommentJsonResponse() throws Exception {
+        //Given
+
+        //When
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+
+        //Then
+    }
+
+
+
+}

--- a/src/test/java/com/fastcampus/fastcampusprojectboard/repository/JpaRepository2Test.java
+++ b/src/test/java/com/fastcampus/fastcampusprojectboard/repository/JpaRepository2Test.java
@@ -39,7 +39,7 @@ class JpaRepository2Test {
         // Then
         assertThat(articles)
                 .isNotNull()
-                .hasSize(1000);
+                .hasSize(123);
     }
 
     @DisplayName("insert 테스트")


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Srping Data REST로 서비스하고, 해당 api 들의 존재 여부만 체크하게 통합테스트 작성