### PR TITLE
인증 기능 구현

### DIFF
--- a/src/main/java/com/fastcampus/fastcampusprojectboard/config/JpaConfig.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/config/JpaConfig.java
@@ -1,9 +1,13 @@
 package com.fastcampus.fastcampusprojectboard.config;
 
+import com.fastcampus.fastcampusprojectboard.dto.request.security.BoardPrincipal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Optional;
 
@@ -11,10 +15,14 @@ import java.util.Optional;
 @Configuration
 public class JpaConfig {
 
+
     @Bean
     public AuditorAware<String> auditorAware() {
-        return () -> Optional.of("uno"); // TODO: 나중에 id값이나 username으로 변경해줘야한다.
-
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getPrincipal)
+                .map(BoardPrincipal.class::cast)
+                .map(BoardPrincipal::getUsername);
     }
-
 }

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/config/SecurityConfig.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/config/SecurityConfig.java
@@ -1,21 +1,55 @@
 package com.fastcampus.fastcampusprojectboard.config;
 
+import com.fastcampus.fastcampusprojectboard.dto.UserAccountDto;
+import com.fastcampus.fastcampusprojectboard.dto.request.security.BoardPrincipal;
+import com.fastcampus.fastcampusprojectboard.repository.UserAccountRepository;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import static org.springframework.security.config.Customizer.withDefaults;
 
 @Configuration
 public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .mvcMatchers(
+                                HttpMethod.GET,
+                                "/",
+                                "/articles",
+                                "/articles/search-hashtag"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin().and()
+                .logout()
+                .logoutSuccessUrl("/")
+                .and()
+                .build();
+    }
 
     @Bean
-    public SecurityFilterChain securityfilterChain(HttpSecurity http) throws Exception {
-        return http
-                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
-                .formLogin().and()
-                .build();
+    public UserDetailsService userDetailsService(UserAccountRepository userAccountRepository) {
+        return username -> userAccountRepository
+                .findById(username)
+                .map(UserAccountDto::from)
+                .map(BoardPrincipal::from)
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다 - username: " + username));
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 
 }

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/controller/ArticleCommentController.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/controller/ArticleCommentController.java
@@ -2,9 +2,11 @@ package com.fastcampus.fastcampusprojectboard.controller;
 
 import com.fastcampus.fastcampusprojectboard.dto.UserAccountDto;
 import com.fastcampus.fastcampusprojectboard.dto.request.ArticleCommentRequest;
+import com.fastcampus.fastcampusprojectboard.dto.request.security.BoardPrincipal;
 import com.fastcampus.fastcampusprojectboard.service.ArticleCommentService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,19 +22,19 @@ public class ArticleCommentController {
     private final ArticleCommentService articleCommentService;
 
     @PostMapping("/new")
-    public String postNewArticleComment(ArticleCommentRequest articleCommentRequest) {
-        //TODO: 인증 정보를 넣어줘야 한다.
-        articleCommentService.saveArticleComment(articleCommentRequest.toDto(UserAccountDto.of(
-                "uno", "password","uno@mail.com","uno",null
-        )));
+    public String postNewArticleComment(ArticleCommentRequest articleCommentRequest,
+                                        @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        articleCommentService.saveArticleComment(articleCommentRequest.toDto(boardPrincipal.toDto()));
 
 
         return "redirect:/articles/" + articleCommentRequest.articleId();
     }
 
     @PostMapping("/{commentId}/delete")
-    public String postDeleteArticleCOmment(@PathVariable Long commentId,@RequestParam Long articleId) {
-        articleCommentService.deleteArticleComment(commentId);
+    public String postDeleteArticleCOmment(@PathVariable Long commentId,@RequestParam Long articleId,
+                                           @AuthenticationPrincipal BoardPrincipal boardPrincipal
+    ) {
+        articleCommentService.deleteArticleComment(commentId, boardPrincipal.getUsername());
         log.info("articleId - {} : commentId - {}", articleId, commentId);
         return "redirect:/articles/" + articleId;
     }

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/controller/ArticleController.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/controller/ArticleController.java
@@ -4,6 +4,7 @@ import com.fastcampus.fastcampusprojectboard.domain.contant.FormStatus;
 import com.fastcampus.fastcampusprojectboard.domain.contant.SearchType;
 import com.fastcampus.fastcampusprojectboard.dto.UserAccountDto;
 import com.fastcampus.fastcampusprojectboard.dto.request.ArticleRequest;
+import com.fastcampus.fastcampusprojectboard.dto.request.security.BoardPrincipal;
 import com.fastcampus.fastcampusprojectboard.dto.response.ArticleCommentResponse;
 import com.fastcampus.fastcampusprojectboard.dto.response.ArticleResponse;
 import com.fastcampus.fastcampusprojectboard.dto.response.ArticleWithCommentsResponse;
@@ -15,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
@@ -85,17 +87,20 @@ public class ArticleController {
     }
 
     @PostMapping("/form")
-    public String postNewArticle(ArticleRequest articleRequest) {
-        // TODO: 인증 정보를 넣어줘야 한다.
-        articleService.saveArticle(articleRequest.toDto(UserAccountDto.of(
-              "uno", "asdf1234", "uno@mail.com", "uno", "memo"
-        )));
+    public String postNewArticle(ArticleRequest articleRequest,
+                                 @AuthenticationPrincipal BoardPrincipal boardPrincipal
+    ) {
+        articleService.saveArticle(articleRequest.toDto(boardPrincipal.toDto()
+        ));
 
         return "redirect:/articles";
     }
 
     @GetMapping("/{articleId}/form")
-    public String updateArticleForm(@PathVariable Long articleId, ModelMap map) {
+    public String updateArticleForm(@PathVariable Long articleId,
+                                    ModelMap map,
+                                    @AuthenticationPrincipal BoardPrincipal boardPrincipal
+    ) {
         ArticleResponse article = ArticleResponse.from(articleService.getArticle(articleId));
 
         map.addAttribute("article", article);
@@ -105,19 +110,21 @@ public class ArticleController {
     }
 
     @PostMapping ("/{articleId}/form")
-    public String updateArticle(@PathVariable Long articleId, ArticleRequest articleRequest) {
+    public String updateArticle(@PathVariable Long articleId, ArticleRequest articleRequest,
+                                @AuthenticationPrincipal BoardPrincipal boardPrincipal
+    ) {
         // TODO: 인증 정보를 넣어줘야 한다.
-        articleService.updateArticle(articleId, articleRequest.toDto(UserAccountDto.of(
-               "uno", "asdf1234", "uno@mail.com", "uno", "memo"
-        )));
+        articleService.updateArticle(articleId, articleRequest.toDto(boardPrincipal.toDto()));
 
         return "redirect:/articles/" + articleId;
     }
 
     @PostMapping ("/{articleId}/delete")
-    public String deleteArticle(@PathVariable Long articleId) {
-        // TODO: 인증 정보를 넣어줘야 한다.
-        articleService.deleteArticle(articleId);
+    public String deleteArticle(@PathVariable Long articleId,
+                                @AuthenticationPrincipal BoardPrincipal boardPrincipal
+    ) {
+
+        articleService.deleteArticle(articleId, boardPrincipal.getUsername());
 
         return "redirect:/articles";
     }

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/dto/request/security/BoardPrincipal.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/dto/request/security/BoardPrincipal.java
@@ -1,0 +1,76 @@
+package com.fastcampus.fastcampusprojectboard.dto.request.security;
+
+import com.fastcampus.fastcampusprojectboard.dto.UserAccountDto;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record BoardPrincipal(
+        String username,
+        String password,
+        Collection<? extends GrantedAuthority> authorities,
+        String email,
+        String nickname,
+        String memo
+) implements UserDetails {
+
+    public static BoardPrincipal of(String username, String password , String email, String nickname, String memo) {
+        Set<RoleType> roleTypes = Set.of(RoleType.USER);
+
+        return new BoardPrincipal(
+                username,
+                password,
+                roleTypes.stream()
+                        .map(RoleType::getName)
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toUnmodifiableSet()),
+                email,
+                nickname,
+                memo
+        );
+    }
+    public static BoardPrincipal from(UserAccountDto dto) {
+        return BoardPrincipal.of(
+                dto.userId(),
+                dto.userPassword(),
+                dto.email(),
+                dto.nickname(),
+                dto.memo()
+        );
+    }
+
+    public UserAccountDto toDto() {
+        return UserAccountDto.of(
+                username,
+                password,
+                email,
+                nickname,
+                memo
+        );
+    }
+
+    @Override public String getPassword() {return password;}
+    @Override public String getUsername() {return username;}
+    @Override public Collection<? extends GrantedAuthority> getAuthorities() {return authorities;}
+
+    @Override public boolean isAccountNonExpired() {return true;}
+    @Override public boolean isAccountNonLocked() {return true;}
+    @Override public boolean isCredentialsNonExpired() {return true;}
+    @Override public boolean isEnabled() {return true;}
+
+    public enum RoleType {
+        USER("ROLE_USER"); //ROLE_을 이용하는건 스프링시큐리티에서 주어지는 규칙이다.
+
+        @Getter private final String name;
+
+        RoleType(String name) {
+            this.name = name;
+        }
+    }
+
+}

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/dto/response/ArticleCommentResponse.java
@@ -10,11 +10,13 @@ public record ArticleCommentResponse(
         String content,
         LocalDateTime createdAt,
         String email,
-        String nickname
+        String nickname,
+        String userId
+
 ) {
 
-    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
-        return new ArticleCommentResponse(id, content, createdAt, email, nickname);
+    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
+        return new ArticleCommentResponse(id, content, createdAt, email, nickname, userId);
     }
 
     public static ArticleCommentResponse from(ArticleCommentDto dto) {
@@ -28,7 +30,8 @@ public record ArticleCommentResponse(
                 dto.content(),
                 dto.createdAt(),
                 dto.userAccountDto().email(),
-                nickname
+                nickname,
+                dto.userAccountDto().userId()
         );
 
     }

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/dto/response/ArticleWithCommentsResponse.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/dto/response/ArticleWithCommentsResponse.java
@@ -15,10 +15,11 @@ public record ArticleWithCommentsResponse(
         LocalDateTime createdAt,
         String email,
         String nickname,
+        String userId,
         Set<ArticleCommentResponse> articleCommentResponse
 ) {
-    public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
-        return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);
+    public static ArticleWithCommentsResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, String userId, Set<ArticleCommentResponse> articleCommentResponses) {
+        return new ArticleWithCommentsResponse(id, title, content, hashtag, createdAt, email, nickname, userId, articleCommentResponses);
     }
 
     public static ArticleWithCommentsResponse from(ArticleWithCommentsDto dto) {
@@ -36,6 +37,7 @@ public record ArticleWithCommentsResponse(
                 dto.createdAt(),
                 dto.userAccount().email(),
                 nickname,
+                dto.userAccount().userId(),
                 dto.articleCommentDtos().stream()
                         .map(ArticleCommentResponse::from)
                         .collect(Collectors.toCollection(LinkedHashSet::new))

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleCommentRepository.java
@@ -19,6 +19,7 @@ public interface ArticleCommentRepository extends
         QuerydslBinderCustomizer<QArticleComment>
 {
     List<ArticleComment> findByArticle_Id(Long articleId);  //Data Jpa 기술인거 같다.
+    void deleteByIdAndUserAccount_UserId(Long articleId, String userId);
     @Override
     default void customize(QuerydslBindings bindings, QArticleComment root) {
         bindings.excludeUnlistedProperties(true);  //선택적인 필드만 검색했으면 좋겠다.

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/repository/ArticleRepository.java
@@ -20,6 +20,7 @@ public interface ArticleRepository extends
         QuerydslPredicateExecutor<Article>,
         QuerydslBinderCustomizer<QArticle>
 {
+    void deleteByIdAndUserAccount_UserId(Long articleId, String userId);
     Page<Article> findByTitleContaining(String title, Pageable pageable);
     Page<Article> findByContentContaining(String content, Pageable pageable);
     Page<Article> findByHashtag(String hashtag, Pageable pageable);

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/service/ArticleCommentService.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/service/ArticleCommentService.java
@@ -4,6 +4,7 @@ import com.fastcampus.fastcampusprojectboard.domain.Article;
 import com.fastcampus.fastcampusprojectboard.domain.ArticleComment;
 import com.fastcampus.fastcampusprojectboard.domain.UserAccount;
 import com.fastcampus.fastcampusprojectboard.dto.ArticleCommentDto;
+import com.fastcampus.fastcampusprojectboard.dto.ArticleDto;
 import com.fastcampus.fastcampusprojectboard.repository.ArticleCommentRepository;
 import com.fastcampus.fastcampusprojectboard.repository.ArticleRepository;
 import com.fastcampus.fastcampusprojectboard.repository.UserAccountRepository;
@@ -42,17 +43,23 @@ public class ArticleCommentService {
         }
     }
 
-    public void updateArticleComment(ArticleCommentDto dto) {
+    public void updateArticle(Long articleId, ArticleDto dto) {
         try {
-            ArticleComment articleComment = articleCommentRepository.getReferenceById(dto.id());
-            if (dto.content() != null) { articleComment.setContent(dto.content()); }
+            Article article = articleRepository.getReferenceById(articleId);
+            UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
+
+            if (article.getUserAccount().equals(userAccount)) {
+                if (dto.title() != null) { article.setTitle(dto.title()); }
+                if (dto.content() != null) { article.setContent(dto.content()); }
+                article.setHashtag(dto.hashtag());
+            }
         } catch (EntityNotFoundException e) {
-            log.warn("댓글 업데이트 실패. 댓글을 찾을 수 없습니다 - dto: {}", dto);
+            log.warn("게시글 업데이트 실패. 게시글을 수정하는데 필요한 정보를 찾을 수 없습니다 - {}", e.getLocalizedMessage());
         }
     }
 
-    public void deleteArticleComment(Long articleCommentId) {
-        articleCommentRepository.deleteById(articleCommentId);
+    public void deleteArticleComment(Long articleCommentId, String userId) {
+        articleCommentRepository.deleteByIdAndUserAccount_UserId(articleCommentId, userId);
     }
 
 }

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/service/ArticleService.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/service/ArticleService.java
@@ -78,8 +78,8 @@ public class ArticleService {
 
     }
 
-    public void deleteArticle(long articleId) {
-        articleRepository.deleteById(articleId);
+    public void deleteArticle(long articleId, String userId) {
+        articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
 
     }
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,8 +1,9 @@
+-- TODO: 테스트용이지만 비밀번호가 노출된 데이터 세팅, 개선하는 것이 좋을 지 고민해보자.
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
-    ('uno', 'asdf1234', 'Uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno')
+    ('uno', '{noop}asdf1234', 'uno', 'uno@mail.com', 'I am Uno.', now(), 'uno', now(), 'uno')
 ;
 insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values
-('uno2', 'asdf1234', 'Uno2', 'uno2@mail.com', 'I am Uno2.', now(), 'uno2', now(), 'uno2')
+('uno2', '{noop}asdf1234', 'uno2', 'uno2@mail.com', 'I am Uno2.', now(), 'uno2', now(), 'uno2')
 ;
 
 -- 123 게시글

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -31,6 +31,18 @@
             <article class="col-md-7 col-lg-8">
                 <p th:text="*{content()}">본문<br><br></p>
             </article>
+
+
+        </div>
+        <div class="row g-5" id="article-buttons">
+            <h5 id="name2"></h5>
+            <h5 id="name3"></h5>
+            <form id="delete-article-form">
+                <div class="pb-5 d-grid gap-2 d-md-block">
+                    <a class="btn btn-success me-md-2" role="button" id="update-article">수정</a>
+                    <button class="btn btn-danger me-md-2" type="submit">삭제</button>
+                </div>
+            </form>
         </div>
 
         <div class="row g-5">
@@ -60,7 +72,7 @@
                                         Lorem ipsum dolor sit amet
                                     </p>
                                 </div>
-                                <div class="col-2 mb-3">
+                                <div class="col-2 mb-3" id="comment-button">
                                     <button type="submit" class="btn btn-outline-danger" id="delete-comment-button">삭제</button>
                                 </div>
                             </div>

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -13,11 +13,17 @@
         <attr sel="time" th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd')}"/>
         <attr sel="a.hashtag" th:text="*{hashtag}"/>
 
-        <attr sel="#comment-form" th:action="@{/comments/new}" th:method="post">
-            <attr sel="#comment-textbox" th:name="content" />
+            <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and ${article.nickname} == ${#authentication.name}">
+                <attr sel="#delete-article-form" th:action="'/articles/' + ${article.id} + '/delete'" th:method="post">
+                    <attr sel="#update-article" th:href="'/articles/' + ${article.id} + '/form'" />
+                </attr>
+            </attr>
         </attr>
+<!--    </attr>-->
+    <attr sel=".article-id" th:name="articleId" th:value="${article.id}" />
+    <attr sel="#comment-form" th:action="@{/comments/new}" th:method="post">
+        <attr sel="#comment-textbox" th:name="content" />
     </attr>
-
 
     <attr sel="#article-comments" th:remove="all-but-first" th:each="comment : ${articleComments}">
 
@@ -27,6 +33,7 @@
                 <attr sel="div/strong" th:text="*{nickname}" />
                 <attr sel="div/small/time" th:datetime="*{createdAt}" th:text="${#temporals.format(comment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
                 <attr sel="div/p" th:text="*{content}" />
+                <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${comment.nickname} == ${#authentication.name}"/>
             </attr>
         </attr>
     </attr>

--- a/src/main/resources/templates/articles/form.th.xml
+++ b/src/main/resources/templates/articles/form.th.xml
@@ -12,4 +12,6 @@
         <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
         <attr sel="#cancel-button" th:onclick="'history.back()'" />
     </attr>
+
+
 </thlogic>

--- a/src/main/resources/templates/articles/index.html
+++ b/src/main/resources/templates/articles/index.html
@@ -78,6 +78,7 @@
             </tr>
             </tbody>
         </table>
+        <a role="button" id="write-button" class="btn btn-primary float-end">글 쓰기</a>
 
         <nav aria-label="Page navigation example">
             <ul id="pagination" class="pagination justify-content-center">

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -51,6 +51,7 @@
             <attr sel="td.user-id" th:text="${article.nickname}"/>
             <attr sel="td.created-at"  th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd HH:mm')}"/>
         </attr>
+    <attr sel="#write-button" sec:authorize="isAuthenticated()" th:href="@{/articles/form}"/>
 
     <attr sel="#pagination">
         <attr sel="li[0]/a"

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -5,7 +5,7 @@
     <title>Title</title>
 </head>
 <body>
-<header id="header" th:fragment="header" class="p-3 bg-dark text-white">
+<header id="header" class="p-3 bg-dark text-white">
     <div class="container">
         <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
@@ -14,8 +14,9 @@
             </ul>
 
             <div class="text-end">
-                <button type="button" class="btn btn-outline-light me-2">Login</button>
-                <button type="button" class="btn btn-warning">Sign-up</button>
+                <span id="username" class="text-white me-2">username</span>
+                <a type="button" id="login" class="btn btn-outline-light me-2">Login</a>
+                <a type="button" id="logout" class="btn btn-outline-light me-2">Logout</a>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -2,4 +2,8 @@
 <thlogic>
     <attr sel="#home" th:href="@{/}" />
     <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+    <attr sel="#username" sec:authorize="isAuthenticated()" sec:authentication="name"/>
+    <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/login}"/>
+    <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}"/>
+
 </thlogic>

--- a/src/test/java/com/fastcampus/fastcampusprojectboard/config/TestSecurityConfig.java
+++ b/src/test/java/com/fastcampus/fastcampusprojectboard/config/TestSecurityConfig.java
@@ -1,0 +1,33 @@
+package com.fastcampus.fastcampusprojectboard.config;
+
+import com.fastcampus.fastcampusprojectboard.domain.UserAccount;
+import com.fastcampus.fastcampusprojectboard.repository.UserAccountRepository;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+
+    @MockBean private UserAccountRepository userAccountRepository;
+
+    @BeforeTestMethod //각 테스트 코드가 실행되기 전에 메소드를 실행하는 어노테이션
+    public void SecuritySetup() {
+        given(userAccountRepository.findById(anyString())).willReturn(Optional.of(UserAccount.of(
+                "unoTest",
+                "pw",
+                "uno-test@email.com",
+                "uno",
+                "memo"
+        )));
+
+
+
+    }
+
+}

--- a/src/test/java/com/fastcampus/fastcampusprojectboard/controller/AuthControllerTest.java
+++ b/src/test/java/com/fastcampus/fastcampusprojectboard/controller/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.fastcampusprojectboard.controller;
 
 import com.fastcampus.fastcampusprojectboard.config.SecurityConfig;
+import com.fastcampus.fastcampusprojectboard.config.TestSecurityConfig;
 import com.fastcampus.fastcampusprojectboard.service.ArticleService;
 import com.fastcampus.fastcampusprojectboard.service.PagenationService;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +18,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
 
 @DisplayName("View 컨트롤러 - 게시글")
-@Import(SecurityConfig.class)
+@Import(TestSecurityConfig.class)
 @WebMvcTest(MainController.class)
 public class AuthControllerTest {
 
@@ -32,7 +33,7 @@ public class AuthControllerTest {
         this.mvc = mvc;
     }
 
-    @DisplayName("[view][GET] 게시글 리스트 (게시판) 페이지 - 정상호출")
+    @DisplayName("[view][GET] 게시글 리스트 (게시판) 페이지 - (로그인) 정상호출")
     @Test
     void givenNothing_whenRequestArticles_thenReturnsArticlesView() throws Exception {
         //Given

--- a/src/test/java/com/fastcampus/fastcampusprojectboard/controller/MainControllerTest.java
+++ b/src/test/java/com/fastcampus/fastcampusprojectboard/controller/MainControllerTest.java
@@ -1,6 +1,7 @@
 package com.fastcampus.fastcampusprojectboard.controller;
 
 import com.fastcampus.fastcampusprojectboard.config.SecurityConfig;
+import com.fastcampus.fastcampusprojectboard.config.TestSecurityConfig;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +13,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@Import({SecurityConfig.class})
+@Import({TestSecurityConfig.class})
 @WebMvcTest(MainController.class)
 public class MainControllerTest {
 

--- a/src/test/java/com/fastcampus/fastcampusprojectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/fastcampus/fastcampusprojectboard/repository/JpaRepositoryTest.java
@@ -7,14 +7,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("JPA 연결 테스트")
-@Import(JpaConfig.class)
+@Import({JpaRepositoryTest.TestJpaConfig.class})
 @DataJpaTest
 //@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 //@ActiveProfiles("testdb")
@@ -93,10 +98,20 @@ class JpaRepositoryTest {
         int deletedCommentSize = article.getArticleComments().size();
 
 //        When
-        articleRepository.delete(article);
+        articleRepository.deleteByIdAndUserAccount_UserId(article.getId(), article.getUserAccount().getUserId());
 
         //Then
         assertThat(articleRepository.count()).isEqualTo(previousCount-1);                        //#4
         assertThat(articleCommentRepository.count()).isEqualTo(previousArticleComment - deletedCommentSize);                        //#4
     }
+
+    @EnableJpaAuditing
+    @TestConfiguration
+    public static class TestJpaConfig {
+        @Bean
+        public AuditorAware<String> auditorAware() {
+            return () -> Optional.of("uno");
+        }
+    }
+
 }

--- a/src/test/java/com/fastcampus/fastcampusprojectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/fastcampus/fastcampusprojectboard/service/ArticleServiceTest.java
@@ -169,16 +169,20 @@ class ArticleServiceTest {
         Article article = createArticle();
         ArticleDto dto = createArticleDto("새 타이틀", "새 내용", "#springboot");
         given(articleRepository.getReferenceById(dto.id())).willReturn(article);
+        given(userAccountRepository.getReferenceById(dto.userAccountDto().userId())).willReturn(dto.userAccountDto().toEntity());
+
 
         // When
         sut.updateArticle(dto.id(),dto);
 
         // Then
+        assertThat(article.getUserAccount().getUserId()).isEqualTo(dto.userAccountDto().userId());
         assertThat(article)
                 .hasFieldOrPropertyWithValue("title", dto.title())
                 .hasFieldOrPropertyWithValue("content", dto.content())
                 .hasFieldOrPropertyWithValue("hashtag", dto.hashtag());
         then(articleRepository).should().getReferenceById(dto.id());
+        then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
     }
 
     @DisplayName("없는 게시글의 수정 정보를 입력하면, 경고 로그를 찍고 아무 것도 하지 않는다.")
@@ -200,13 +204,15 @@ class ArticleServiceTest {
     void givenArticleId_whenDeletingArticle_thenDeletesArticle() {
         // Given
         Long articleId = 1L;
-        willDoNothing().given(articleRepository).deleteById(articleId);
+        UserAccount userAccount = createUserAccount();
+        String userId = userAccount.getUserId();
+        willDoNothing().given(articleRepository).deleteByIdAndUserAccount_UserId(articleId, userId);
 
         // When
-        sut.deleteArticle(1L);
+        sut.deleteArticle(1L, userId);
 
         // Then
-        then(articleRepository).should().deleteById(articleId);
+        then(articleRepository).should().deleteByIdAndUserAccount_UserId(articleId, userId);
     }
 
 
@@ -215,7 +221,7 @@ class ArticleServiceTest {
                 "uno",
                 "password",
                 "uno@email.com",
-                "Uno",
+                "uno",
                 null
         );
     }
@@ -255,7 +261,7 @@ class ArticleServiceTest {
                 "uno",
                 LocalDateTime.now(),
                 "uno",
-                "Uno",
+                "uno",
                 "password",
                 "uno@mail.com",
                 "nickname",


### PR DESCRIPTION
인증 기능의 실제 뷰 표현

인증기능에 필요한 SecurityConfig에서 접근이 가능한 페이지를 설정했다.
/
/articles
/articles/search-hashtag
그 외에 페이지는 특정 회원만 조회할 수 있다.

서비스, 레포지토리, response 등 게시글, 댓글을 수정 삭제하는 코드를 추가했다.
data jpa를 이용해 게시글 id와 작성자 userid를 이용하여 수정, 삭제하게 설계했다.

data.sql
패스워드 인코더가 읽을수 있게 패스워드 데이터를 알맞게 수정함

test
유저를 필요로 하는 파일 마다 따로 유저를 선언해주었는데
중복적인 일을 피해서 작업할 수 있게 설정했다.




this is closes #30 