### PR TITLE
#60 - 필드 접근을 Getter로 변경

### DIFF
--- a/src/main/java/com/fastcampus/fastcampusprojectboard/domain/Article.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/domain/Article.java
@@ -62,11 +62,11 @@ public class Article extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof Article article)) return false;
-        return id != null && id.equals(article.id);
+        return this.getId() != null && this.getId().equals(article.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/domain/ArticleComment.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/domain/ArticleComment.java
@@ -60,11 +60,11 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment articleComment)) return false;
-        return id != null && id.equals(articleComment.id);
+        return this.getId() != null && this.getId().equals(articleComment.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/fastcampus/fastcampusprojectboard/domain/UserAccount.java
+++ b/src/main/java/com/fastcampus/fastcampusprojectboard/domain/UserAccount.java
@@ -45,11 +45,11 @@ public class UserAccount extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.userId);
+        return this.getUserId() != null && this.getUserId().equals(userAccount.userId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
스프링 데이터 JPA 엔티티를 다룰 때, 엔티티 데이터는 하이버네이트 구현체가 만든 프록시 데이터 객체를 이용하여 지연 로딩될 수 있다. 따라서 에닡티를 조회할 때 필드에 직접 접근하면 id == null 인 상황이 있을 수 있고, 이러면 올바른 비교를 못한다. Getter를 사용하면 이러한 문제를 해결할 수 있다.
this is closes #60